### PR TITLE
use RNA-seq as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Galaxy - RNA workbench
 
-FROM bgruening/galaxy-ngs-preprocessing:16.10
+FROM bgruening/galaxy-rna-seq:16.10
 
 MAINTAINER Björn A. Grüning, bjoern.gruening@gmail.com
 


### PR DESCRIPTION
It seems travis has a space limit and we are hitting it. We do want to have RNA-seq tools in this flavor correct? Is it ok to merge and deactivate tests? Consider an other CI service? Ask travis for more space?