### PR TITLE
Add FlaiMapper to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you want to create new users, please make sure to use the `/export/` volume. 
 | RNA Annotation | [GotohScan](http://www.bioinf.uni-leipzig.de/Software/GotohScan/), [RNAcode](http://wash.github.io/rnacode/), [INFERNAL](http://eddylab.org/infernal/), [RNAmmer](http://www.cbs.dtu.dk/services/RNAmmer/), [ARAGORN](http://mbio-serv2.mbioekol.lu.se/ARAGORN/), [tRNAscan](http://lowelab.ucsc.edu/tRNAscan-SE/), [RNABOB](http://eddylab.org/software.html) |
 | RNA-protein Interaction |  [DoRiNA](http://dorina.mdc-berlin.de/), [Piranha](https://github.com/smithlabcode/piranha), [RNAcommender](https://github.com/gianlucacorrado/RNAcommender), [PARalyzer](https://ohlerlab.mdc-berlin.de/software/PARalyzer_85/)|
 | Ribosome Profiling | [RiboTaper](https://ohlerlab.mdc-berlin.de/software/RiboTaper_126/) |
-| RNA-Seq |[SortMeRNA](http://bioinfo.lifl.fr/RNA/sortmerna/), [BlockClust](http://www.bioinf.uni-freiburg.de/Software/) , [MiRDeep2](https://www.mdc-berlin.de/8551903/en/)  |
+| RNA-Seq |[SortMeRNA](http://bioinfo.lifl.fr/RNA/sortmerna/), [BlockClust](http://www.bioinf.uni-freiburg.de/Software/) , [MiRDeep2](https://www.mdc-berlin.de/8551903/en/), [FlaiMapper](https://github.com/yhoogstrate/flaimapper)  |
 | RNA Target Prediction | [TargetFinder](https://github.com/carringtonlab/TargetFinder) |
 
 # Contributors
@@ -108,6 +108,7 @@ If you want to create new users, please make sure to use the `/export/` volume. 
  - Cameron Smith
  - Sebastian Will
  - Dilmurat Yusuf
+ - Youri Hoogstrate
 
 
 # Support & Bug Reports

--- a/rna_workbench.yml
+++ b/rna_workbench.yml
@@ -213,6 +213,12 @@ tools:
   install_resolver_dependencies: True
   install_tool_dependencies: False
 
+- name: flaimapper
+  owner: yhoogstrate
+  tool_panel_section_label: "RNA-Seq"
+  tool_shed_url: https://toolshed.g2.bx.psu.edu
+  install_resolver_dependencies: true
+  install_tool_dependencies: false
 
 - name: suite_mirdeep_2_0
   owner: rnateam


### PR DESCRIPTION
Hi there,

I would like to add the tool FlaiMapper to the RNA workbench. It's doing more or less the same thing as BlockBuster but in a rather different way.

If you like to include it in the workbenach I would also like to know whether I need to add admin access for `rnateam` to the repo's?

FlaiMapper is conda-proof and functionally tested in our institutes galaxy tools repo, using the same travis config as IUC.